### PR TITLE
Fix script path

### DIFF
--- a/bin/adbp
+++ b/bin/adbp
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-adb_peco.sh adb $1
+SCRIPT=`dirname $0`/adb_peco.sh
+$SCRIPT adb $1

--- a/bin/pidcatp
+++ b/bin/pidcatp
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-adb_peco.sh pidcat
+SCRIPT=`dirname $0`/adb_peco.sh
+$SCRIPT pidcat


### PR DESCRIPTION
`adbp` and `pidcatp` fail when `adb_peco.sh` is not in `PATH`.

```
$ git clone git@github.com:tomorrowkey/adb-peco.git
$ cd adb-peco
$ ./bin/adbp 
./bin/adbp: line 3: adb_peco.sh: command not found
$ ./bin/pidcatp 
./bin/pidcatp: line 3: adb_peco.sh: command not found
```

This PR fix script.
