### PR TITLE
adbp や pidcatp に対して symlink を作成して使用することが出来るようにしました。

### DIFF
--- a/bin/adbp
+++ b/bin/adbp
@@ -1,4 +1,10 @@
 #!/bin/bash
 
-SCRIPT=`dirname $0`/adb_peco.sh
-$SCRIPT adb "$@"
+SCRIPT="$0"
+
+if [ -n "`readlink "$SCRIPT"`" ] ; then
+    SCRIPT="`readlink "$SCRIPT"`"
+fi
+
+SCRIPT="`dirname "$SCRIPT"`/adb_peco.sh"
+"$SCRIPT" adb "$@"

--- a/bin/pidcatp
+++ b/bin/pidcatp
@@ -1,4 +1,10 @@
 #!/bin/bash
 
-SCRIPT=`dirname $0`/adb_peco.sh
-$SCRIPT pidcat "$@"
+SCRIPT="$0"
+
+if [ -n "`readlink "$SCRIPT"`" ] ; then
+    SCRIPT="`readlink "$SCRIPT"`"
+fi
+
+SCRIPT="`dirname "$SCRIPT"`/adb_peco.sh"
+"$SCRIPT" pidcat "$@"


### PR DESCRIPTION
たとえば、 ln -s ~/adb-peco/bin/adbp ~/bin/ のような使い方です。
