### PR TITLE
Execute command without peco if serial number is not necessary

### DIFF
--- a/bin/adb_peco.sh
+++ b/bin/adb_peco.sh
@@ -12,6 +12,14 @@ if [ $# -eq 1 ]; then
     fi
 fi
 
+if [ $2 == 'version' ]; then
+    echo 'adb-peco version 1.1.0'
+fi
+
+case $2 in
+    'devices'| 'version' | 'help' | 'connect' | 'disconnect' | 'wait-for-device' | 'start-server' | 'kill-server' ) $1 ${@:2}; exit;;
+esac
+
 count=`adb devices | sed '/^$/d' | wc -l`
 
 if [ $count -eq 1 ]; then


### PR DESCRIPTION
`device`や`kill-server`などはデバイスの指定は必要ないので、接続されているデバイスの数に関わらず実行されるよう修正しました。