### PR TITLE
Use `qualifier` for IP connected devices

### DIFF
--- a/lib/adb/peco.rb
+++ b/lib/adb/peco.rb
@@ -14,9 +14,9 @@ module Adb
       return nil if devices.size <= 1 || devices.size == 0
 
       device = PecoSelector.select_from(devices.map{|device|
-        ["#{device.model} (#{device.serial})", device]
+        ["#{device.model} (#{device.qualifier})", device]
       }).first
-      "-s #{device.serial}"
+      "-s #{device.qualifier}"
 
     rescue PecoSelector::PecoUnavailableError => e
       puts e.message


### PR DESCRIPTION
Currently, if devices are connected with `connect <ip>`,
`adb-peco` fails like:
```
+ adb -s 0146975B1201C013 shell input text hello
error: device '0146975B1201C013' not found
```
It looks like adb-peco always uses device serial for `adb -s`.
But when devices are connected via `adb connect <ip>`, ip should be used for `adb -s <serial>`.

This is consistent that `adb devices` shows ip.
```
+ adb  devices
List of devices attached
00c7f0762188ac2c        device
192.168.43.163:5555     device
```